### PR TITLE
Go 1.11 Modules Support & Linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,31 @@ language: go
 
 go:
   - 1.5
+  - 1.11.x
   - tip
 
+env:
+  global:
+    - GO111MODULE=on
+
+before_install:
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin latest
+
+install:
+  - go mod download
+
 script:
-  - go test
+  - go mod tidy && git diff --exit-code; code=$?; git checkout -- .; (exit $code)
+  - go test -race -cover -coverprofile=coverage.txt -covermode=atomic ./...
+  - golangci-lint run
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - go: tip
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.5
   - 1.11.x
   - tip
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/goware/urlx
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	golang.org/x/net v0.0.0-20190213061140-3a22650c66bd
+	golang.org/x/text v0.3.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
+github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+golang.org/x/net v0.0.0-20190213061140-3a22650c66bd h1:HuTn7WObtcDo9uEEU7rEqL0jYthdXAmZ6PP+meazmaU=
+golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/urlx.go
+++ b/urlx.go
@@ -20,7 +20,7 @@ func defaultToScheme(rawURL, defaultScheme string) string {
 		// Leading double slashes (any scheme). Force http.
 		rawURL = defaultScheme + ":" + rawURL
 	}
-	if strings.Index(rawURL, "://") == -1 {
+	if !strings.Contains(rawURL, "://") {
 		// Missing scheme. Force http.
 		rawURL = defaultScheme + "://" + rawURL
 	}
@@ -104,7 +104,7 @@ func SplitHostPort(u *url.URL) (host, port string, err error) {
 	// Find last colon.
 	if i := strings.LastIndex(host, ":"); i != -1 {
 		// If we're not inside [IPv6] brackets, split host:port.
-		if len(host) > i && strings.Index(host[i:], "]") == -1 {
+		if len(host) > i && !strings.Contains(host[i:], "]") {
 			port = host[i+1:]
 			host = host[:i]
 		}


### PR DESCRIPTION
Primary add here is support for Go 1.11 modules (you'll want to tag a release, such as 1.0.1 or something after you merge this)

Additionally, utilizes the golangci-lint project for tons of fun linter support. I even cleaned up some of the simplification it recommended.