### PR TITLE
List numeration typo fix

### DIFF
--- a/urlx.go
+++ b/urlx.go
@@ -33,7 +33,7 @@ func defaultToScheme(rawURL, defaultScheme string) string {
 // 1. It forces the default scheme and port to http
 // 2. It favors absolute paths over relative ones, thus "example.com"
 //    is parsed into url.Host instead of url.Path.
-// 4. It lowercases the Host (not only the Scheme).
+// 3. It lowercases the Host (not only the Scheme).
 func Parse(rawURL string) (*url.URL, error) {
 	return ParseWithDefaultScheme(rawURL, "http")
 }


### PR DESCRIPTION
Although, third point is missed, it probably should have been added. I think the intention was to explain what `checkHost()` function is doing.